### PR TITLE
bounce_,management added ungetestet

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -81,6 +81,7 @@ multinewsletter_config_autosend = Autosend Option aktivieren und Autosend Cronjo
 multinewsletter_config_install_cronjob = Wenn Sie die Autosend oder AutoCleanUp Option aktivieren möchten, müssen Sie das Cronjob Addon installieren.
 multinewsletter_config_install_yform3_required = Für dieses Modul wird YForm 3 oder höher benötigt.
 multinewsletter_config_title_serverlimits = Serverlimits beim Versand
+multinewsletter_config_title_bounce_management = Bounce Management (IMAP)
 multinewsletter_config_title_testmails = Voreinstellungen für Testmails
 multinewsletter_config_default_test_anrede = Anrede
 multinewsletter_config_default_test_nachname = Nachname
@@ -263,6 +264,42 @@ multinewsletter_help_chapter_faq = FAQ
 
 multinewsletter_hinzufuegen = Hinzufügen
 multinewsletter_delete = Eintrag gelöscht
+
+# Bounce Management
+multinewsletter_expl_bounce_management = Das Bounce Management verarbeitet automatisch zurückgewiesene E-Mails über ein IMAP-Postfach. Hard Bounces führen zur sofortigen Deaktivierung, Soft Bounces nach 3 Versuchen, Spam-Beschwerden zur Löschung des Abonnements.
+multinewsletter_config_bounce_enabled = Bounce Management aktivieren
+multinewsletter_config_bounce_imap_host = IMAP Server
+multinewsletter_config_bounce_imap_port = IMAP Port
+multinewsletter_config_bounce_imap_user = IMAP Benutzername
+multinewsletter_config_bounce_imap_password = IMAP Passwort
+multinewsletter_config_bounce_imap_ssl = SSL/TLS verwenden
+multinewsletter_config_bounce_imap_mailbox = IMAP Postfach
+multinewsletter_config_bounce_auto_process = Automatische Verarbeitung per Cronjob aktivieren
+multinewsletter_config_test_imap_connection = IMAP Verbindung testen
+
+multinewsletter_bounce_management = Bounce Management
+multinewsletter_bounce_management_description = Automatische Verwaltung von zurückgewiesenen E-Mails über IMAP-Postfach.
+multinewsletter_bounce_management_disabled = Bounce Management ist deaktiviert. Bitte aktivieren Sie es in den Einstellungen.
+multinewsletter_enable_bounce_management = Bounce Management aktivieren
+multinewsletter_process_bounces_manually = Bounces manuell verarbeiten
+multinewsletter_bounce_processing_success = {0} E-Mails verarbeitet: {1} Hard Bounces, {2} Soft Bounces, {3} Spam-Beschwerden
+multinewsletter_bounce_no_emails = Keine neuen Bounce-E-Mails gefunden
+multinewsletter_bounce_statistics = Bounce Statistiken
+multinewsletter_total_bounces_30_days = Bounces (30 Tage)
+multinewsletter_hard_bounces = Hard Bounces
+multinewsletter_soft_bounces = Soft Bounces
+multinewsletter_spam_complaints = Spam-Beschwerden
+multinewsletter_bounce_stats_error = Fehler beim Laden der Bounce-Statistiken
+multinewsletter_recent_bounces = Aktuelle Bounces
+multinewsletter_bounce_date = Datum
+multinewsletter_bounce_user = Benutzer
+multinewsletter_bounce_type = Typ
+multinewsletter_bounce_subject = Betreff
+multinewsletter_hard_bounce = Hard Bounce
+multinewsletter_soft_bounce = Soft Bounce
+multinewsletter_spam_complaint = Spam-Beschwerde
+multinewsletter_no_bounces_yet = Noch keine Bounces verzeichnet
+multinewsletter_bounce_list_error = Fehler beim Laden der Bounce-Liste
 
 multinewsletter_lang_no_fallback = kein Newsletter versenden
 multinewsletter_lang_d2u_helper = Ausgangssprache aus den Einstellungen des D2U Helper Addons verwenden

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -264,5 +264,17 @@ multinewsletter_help_chapter_faq = FAQ
 multinewsletter_hinzufuegen = Add
 multinewsletter_delete = Entry deleted
 
+# Bounce Management
+multinewsletter_expl_bounce_management = Bounce management automatically processes rejected emails via an IMAP mailbox. Hard bounces lead to immediate deactivation, soft bounces after 3 attempts, spam complaints to subscription deletion.
+multinewsletter_config_bounce_enabled = Enable bounce management
+multinewsletter_config_bounce_imap_host = IMAP Server
+multinewsletter_config_bounce_imap_port = IMAP Port
+multinewsletter_config_bounce_imap_user = IMAP Username
+multinewsletter_config_bounce_imap_password = IMAP Password
+multinewsletter_config_bounce_imap_ssl = Use SSL/TLS
+multinewsletter_config_bounce_imap_mailbox = IMAP Mailbox
+multinewsletter_config_bounce_auto_process = Enable automatic processing via cronjob
+multinewsletter_config_test_imap_connection = Test IMAP Connection
+
 multinewsletter_lang_no_fallback = send nothing
 multinewsletter_lang_d2u_helper = Use D2U Helper base language

--- a/lib/BounceHandler.php
+++ b/lib/BounceHandler.php
@@ -1,0 +1,502 @@
+<?php
+
+namespace FriendsOfRedaxo\MultiNewsletter;
+
+use rex;
+use rex_addon;
+use rex_config;
+use rex_extension;
+use rex_extension_point;
+use rex_sql;
+use rex_view;
+
+/**
+ * IMAP-based Bounce Handler for MultiNewsletter
+ * Processes bounced emails to automatically manage user subscriptions
+ * 
+ * @author MultiNewsletter Team
+ */
+class BounceHandler
+{
+    /** @var resource IMAP connection resource */
+    private $imap_connection;
+    
+    /** @var string IMAP server host */
+    private string $imap_host = '';
+    
+    /** @var int IMAP server port */
+    private int $imap_port = 993;
+    
+    /** @var string IMAP username */
+    private string $imap_user = '';
+    
+    /** @var string IMAP password */
+    private string $imap_password = '';
+    
+    /** @var bool Use SSL/TLS */
+    private bool $imap_ssl = true;
+    
+    /** @var string IMAP mailbox name */
+    private string $imap_mailbox = 'INBOX';
+    
+    /** @var array<string> Processed message UIDs to avoid duplicates */
+    private array $processed_uids = [];
+
+    /**
+     * Initialize BounceHandler with IMAP configuration
+     */
+    public function __construct()
+    {
+        $addon = rex_addon::get('multinewsletter');
+        $this->imap_host = (string) $addon->getConfig('bounce_imap_host', '');
+        $this->imap_port = (int) $addon->getConfig('bounce_imap_port', 993);
+        $this->imap_user = (string) $addon->getConfig('bounce_imap_user', '');
+        $this->imap_password = (string) $addon->getConfig('bounce_imap_password', '');
+        $this->imap_ssl = (bool) $addon->getConfig('bounce_imap_ssl', true);
+        $this->imap_mailbox = (string) $addon->getConfig('bounce_imap_mailbox', 'INBOX');
+        
+        $this->loadProcessedUIDs();
+    }
+
+    /**
+     * Connect to IMAP server
+     * @return bool true if connection successful
+     */
+    public function connect(): bool
+    {
+        if (!extension_loaded('imap')) {
+            throw new \Exception('PHP IMAP extension is not installed');
+        }
+
+        $mailbox = '{' . $this->imap_host . ':' . $this->imap_port;
+        if ($this->imap_ssl) {
+            $mailbox .= '/imap/ssl/novalidate-cert';
+        }
+        $mailbox .= '}' . $this->imap_mailbox;
+
+        $this->imap_connection = @imap_open($mailbox, $this->imap_user, $this->imap_password);
+        
+        if (false === $this->imap_connection) {
+            throw new \Exception('IMAP connection failed: ' . imap_last_error());
+        }
+
+        return true;
+    }
+
+    /**
+     * Disconnect from IMAP server
+     */
+    public function disconnect(): void
+    {
+        if (is_resource($this->imap_connection)) {
+            imap_close($this->imap_connection);
+        }
+    }
+
+    /**
+     * Process bounced emails from IMAP inbox
+     * @return array Array with processing results
+     */
+    public function processBounces(): array
+    {
+        $results = [
+            'processed' => 0,
+            'hard_bounces' => 0,
+            'soft_bounces' => 0,
+            'spam_complaints' => 0,
+            'errors' => []
+        ];
+
+        if (!$this->connect()) {
+            $results['errors'][] = 'Failed to connect to IMAP server';
+            return $results;
+        }
+
+        try {
+            $emails = imap_search($this->imap_connection, 'UNSEEN');
+            
+            if (false === $emails) {
+                return $results; // No new emails
+            }
+
+            foreach ($emails as $email_number) {
+                $uid = imap_uid($this->imap_connection, $email_number);
+                
+                // Skip if already processed
+                if (in_array($uid, $this->processed_uids, true)) {
+                    continue;
+                }
+
+                $bounce_result = $this->processBounceEmail($email_number);
+                
+                if ($bounce_result) {
+                    $results['processed']++;
+                    $results[$bounce_result['type']]++;
+                    
+                    // Mark as processed
+                    $this->processed_uids[] = $uid;
+                    
+                    // Mark email as seen
+                    imap_setflag_full($this->imap_connection, $uid, '\\Seen', ST_UID);
+                }
+            }
+            
+            $this->saveProcessedUIDs();
+            
+        } catch (\Exception $e) {
+            $results['errors'][] = $e->getMessage();
+        } finally {
+            $this->disconnect();
+        }
+
+        return $results;
+    }
+
+    /**
+     * Process individual bounced email
+     * @param int $email_number Email number in mailbox
+     * @return array|null Bounce information or null if not a bounce
+     */
+    private function processBounceEmail(int $email_number): ?array
+    {
+        $header = imap_headerinfo($this->imap_connection, $email_number);
+        $body = imap_body($this->imap_connection, $email_number);
+        $structure = imap_fetchstructure($this->imap_connection, $email_number);
+
+        // Extract original recipient email from bounce
+        $bounced_email = $this->extractBouncedEmail($header, $body, $structure);
+        
+        if (!$bounced_email) {
+            return null; // Not a valid bounce
+        }
+
+        // Determine bounce type
+        $bounce_type = $this->determineBounceType($header, $body);
+        
+        // Process bounce based on type
+        $this->handleBounce($bounced_email, $bounce_type, $header, $body);
+        
+        return [
+            'email' => $bounced_email,
+            'type' => $bounce_type,
+            'subject' => $header->subject ?? '',
+            'date' => date('Y-m-d H:i:s', $header->udate ?? time())
+        ];
+    }
+
+    /**
+     * Extract bounced email address from bounce message
+     * @param object $header Email header
+     * @param string $body Email body
+     * @param object $structure Email structure
+     * @return string|null Bounced email address
+     */
+    private function extractBouncedEmail(object $header, string $body, object $structure): ?string
+    {
+        // Common patterns for extracting email from bounce messages
+        $patterns = [
+            '/(?:Final-Recipient:|final-recipient:)\s*(?:rfc822;)?\s*([^\s]+@[^\s]+)/i',
+            '/(?:Original-Recipient:|original-recipient:)\s*(?:rfc822;)?\s*([^\s]+@[^\s]+)/i',
+            '/(?:User-Agent:|Return-Path:)\s*<([^>]+@[^>]+)>/i',
+            '/(?:failed|bounced|undeliverable).*?(?:to|for)\s+([^\s]+@[^\s]+)/i',
+            '/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/i' // Generic email pattern
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $body, $matches)) {
+                $email = filter_var($matches[1], FILTER_VALIDATE_EMAIL);
+                if ($email && $this->isNewsletterRecipient($email)) {
+                    return $email;
+                }
+            }
+        }
+
+        // Try to extract from headers
+        if (isset($header->reply_to[0])) {
+            $email = $header->reply_to[0]->mailbox . '@' . $header->reply_to[0]->host;
+            if (filter_var($email, FILTER_VALIDATE_EMAIL) && $this->isNewsletterRecipient($email)) {
+                return $email;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine bounce type (hard, soft, spam complaint)
+     * @param object $header Email header
+     * @param string $body Email body
+     * @return string Bounce type
+     */
+    private function determineBounceType(object $header, string $body): string
+    {
+        $body_lower = strtolower($body);
+        $subject_lower = strtolower($header->subject ?? '');
+
+        // Hard bounce indicators
+        $hard_bounce_indicators = [
+            'user unknown', 'mailbox unavailable', 'invalid recipient',
+            'no such user', 'user not found', 'recipient rejected',
+            'mailbox does not exist', 'invalid address', 'user disabled',
+            '5.1.1', '5.1.2', '5.1.3', '5.2.1', '5.7.1'
+        ];
+
+        // Soft bounce indicators  
+        $soft_bounce_indicators = [
+            'mailbox full', 'quota exceeded', 'temporary failure',
+            'try again later', 'mailbox temporarily unavailable',
+            'server busy', 'message deferred',
+            '4.2.2', '4.3.1', '4.3.2', '4.4.7'
+        ];
+
+        // Spam complaint indicators
+        $spam_indicators = [
+            'spam', 'junk', 'abuse', 'complaint', 'unsubscribe',
+            'feedback loop', 'fbl', 'x-hmxmroriginalrecipient'
+        ];
+
+        // Check for spam complaints first
+        foreach ($spam_indicators as $indicator) {
+            if (str_contains($body_lower, $indicator) || str_contains($subject_lower, $indicator)) {
+                return 'spam_complaints';
+            }
+        }
+
+        // Check for hard bounces
+        foreach ($hard_bounce_indicators as $indicator) {
+            if (str_contains($body_lower, $indicator) || str_contains($subject_lower, $indicator)) {
+                return 'hard_bounces';
+            }
+        }
+
+        // Check for soft bounces
+        foreach ($soft_bounce_indicators as $indicator) {
+            if (str_contains($body_lower, $indicator) || str_contains($subject_lower, $indicator)) {
+                return 'soft_bounces';
+            }
+        }
+
+        // Default to soft bounce if uncertain
+        return 'soft_bounces';
+    }
+
+    /**
+     * Handle bounce based on type
+     * @param string $email Bounced email address
+     * @param string $bounce_type Type of bounce
+     * @param object $header Email header
+     * @param string $body Email body
+     */
+    private function handleBounce(string $email, string $bounce_type, object $header, string $body): void
+    {
+        $user = User::initByMail($email);
+        
+        if (!($user instanceof User)) {
+            return; // User not found
+        }
+
+        // Log bounce
+        $this->logBounce($user->id, $bounce_type, $header->subject ?? '', $body);
+
+        switch ($bounce_type) {
+            case 'hard_bounces':
+                $this->handleHardBounce($user);
+                break;
+                
+            case 'soft_bounces':
+                $this->handleSoftBounce($user);
+                break;
+                
+            case 'spam_complaints':
+                $this->handleSpamComplaint($user);
+                break;
+        }
+
+        // Extension point for custom bounce handling
+        rex_extension::registerPoint(new rex_extension_point('MULTINEWSLETTER_BOUNCE_PROCESSED', [
+            'user' => $user,
+            'bounce_type' => $bounce_type,
+            'email' => $email
+        ]));
+    }
+
+    /**
+     * Handle hard bounce - immediately deactivate user
+     * @param User $user Newsletter user
+     */
+    private function handleHardBounce(User $user): void
+    {
+        $user->status = 0; // Deactivate
+        $user->save();
+        
+        echo rex_view::info("Hard bounce: User {$user->email} deactivated");
+    }
+
+    /**
+     * Handle soft bounce - increment counter, deactivate after threshold
+     * @param User $user Newsletter user
+     */
+    private function handleSoftBounce(User $user): void
+    {
+        $soft_bounce_count = $this->getSoftBounceCount($user->id);
+        $soft_bounce_count++;
+        
+        $this->updateSoftBounceCount($user->id, $soft_bounce_count);
+        
+        // Deactivate after 3 soft bounces
+        if ($soft_bounce_count >= 3) {
+            $user->status = 0;
+            $user->save();
+            echo rex_view::warning("Soft bounce threshold reached: User {$user->email} deactivated");
+        } else {
+            echo rex_view::info("Soft bounce #{$soft_bounce_count}: {$user->email}");
+        }
+    }
+
+    /**
+     * Handle spam complaint - immediately unsubscribe
+     * @param User $user Newsletter user
+     */
+    private function handleSpamComplaint(User $user): void
+    {
+        $user->unsubscribe('delete');
+        
+        echo rex_view::warning("Spam complaint: User {$user->email} unsubscribed");
+    }
+
+    /**
+     * Check if email is a newsletter recipient
+     * @param string $email Email address to check
+     * @return bool true if email is newsletter recipient
+     */
+    private function isNewsletterRecipient(string $email): bool
+    {
+        $sql = rex_sql::factory();
+        $sql->setQuery('SELECT id FROM ' . rex::getTablePrefix() . '375_user WHERE email = ?', [$email]);
+        
+        return $sql->getRows() > 0;
+    }
+
+    /**
+     * Log bounce to database
+     * @param int $user_id User ID
+     * @param string $bounce_type Bounce type
+     * @param string $subject Email subject
+     * @param string $body Email body
+     */
+    private function logBounce(int $user_id, string $bounce_type, string $subject, string $body): void
+    {
+        $sql = rex_sql::factory();
+        $sql->setTable(rex::getTablePrefix() . '375_bounces');
+        $sql->setValue('user_id', $user_id);
+        $sql->setValue('bounce_type', $bounce_type);
+        $sql->setValue('subject', $subject);
+        $sql->setValue('body_excerpt', substr($body, 0, 1000));
+        $sql->setValue('created_at', date('Y-m-d H:i:s'));
+        $sql->insert();
+    }
+
+    /**
+     * Get soft bounce count for user
+     * @param int $user_id User ID
+     * @return int Soft bounce count
+     */
+    private function getSoftBounceCount(int $user_id): int
+    {
+        $sql = rex_sql::factory();
+        $sql->setQuery(
+            'SELECT soft_bounce_count FROM ' . rex::getTablePrefix() . '375_user WHERE id = ?',
+            [$user_id]
+        );
+        
+        return (int) $sql->getValue('soft_bounce_count');
+    }
+
+    /**
+     * Update soft bounce count for user
+     * @param int $user_id User ID
+     * @param int $count New bounce count
+     */
+    private function updateSoftBounceCount(int $user_id, int $count): void
+    {
+        $sql = rex_sql::factory();
+        $sql->setQuery(
+            'UPDATE ' . rex::getTablePrefix() . '375_user SET soft_bounce_count = ? WHERE id = ?',
+            [$count, $user_id]
+        );
+    }
+
+    /**
+     * Load processed message UIDs from database
+     */
+    private function loadProcessedUIDs(): void
+    {
+        $addon = rex_addon::get('multinewsletter');
+        $uids_string = (string) $addon->getConfig('bounce_processed_uids', '');
+        
+        if ('' !== $uids_string) {
+            $this->processed_uids = explode(',', $uids_string);
+        }
+    }
+
+    /**
+     * Save processed message UIDs to database
+     */
+    private function saveProcessedUIDs(): void
+    {
+        // Keep only last 1000 UIDs to prevent unlimited growth
+        $this->processed_uids = array_slice($this->processed_uids, -1000);
+        
+        $addon = rex_addon::get('multinewsletter');
+        rex_config::set('multinewsletter', 'bounce_processed_uids', implode(',', $this->processed_uids));
+    }
+
+    /**
+     * Test IMAP connection
+     * @return bool true if connection successful
+     */
+    public function testConnection(): bool
+    {
+        try {
+            $this->connect();
+            $this->disconnect();
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Get bounce statistics
+     * @param int $days Number of days to look back
+     * @return array Bounce statistics
+     */
+    public function getBounceStatistics(int $days = 30): array
+    {
+        $sql = rex_sql::factory();
+        $sql->setQuery(
+            'SELECT bounce_type, COUNT(*) as count 
+             FROM ' . rex::getTablePrefix() . '375_bounces 
+             WHERE created_at > DATE_SUB(NOW(), INTERVAL ? DAY) 
+             GROUP BY bounce_type',
+            [$days]
+        );
+
+        $stats = [
+            'hard_bounces' => 0,
+            'soft_bounces' => 0, 
+            'spam_complaints' => 0,
+            'total' => 0
+        ];
+
+        for ($i = 0; $i < $sql->getRows(); $i++) {
+            $type = $sql->getValue('bounce_type');
+            $count = (int) $sql->getValue('count');
+            $stats[$type] = $count;
+            $stats['total'] += $count;
+            $sql->next();
+        }
+
+        return $stats;
+    }
+}

--- a/lib/CronjobBounceProcessor.php
+++ b/lib/CronjobBounceProcessor.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace FriendsOfRedaxo\MultiNewsletter;
+
+/**
+ * Cronjob for processing bounced emails via IMAP
+ * 
+ * @author MultiNewsletter Team
+ */
+class CronjobBounceProcessor extends \TobiasKrais\D2UHelper\ACronJob
+{
+    /**
+     * Create a new instance of bounce processor cronjob
+     * @return self CronJob object
+     */
+    public static function factory()
+    {
+        $cronjob = new self();
+        $cronjob->name = 'MultiNewsletter Bounce Processor';
+        return $cronjob;
+    }
+
+    /**
+     * Install bounce processor cronjob
+     */
+    public function install(): void
+    {
+        $description = 'Verarbeitet Bounce-E-Mails über IMAP und verwaltet automatisch Benutzerabonnements basierend auf E-Mail-Zustellungsfehlern.';
+        $php_code = '<?php \\\\\\\\FriendsOfRedaxo\\\\\\\\MultiNewsletter\\\\\\\\CronjobBounceProcessor::processBounces(); ?>';
+        $interval = '{"minutes":[0,30],"hours":"all","days":"all","weekdays":"all","months":"all"}'; // Every 30 minutes
+        $activate = false; // Not activated by default
+        self::save($description, $php_code, $interval, $activate);
+    }
+
+    /**
+     * Process bounced emails
+     */
+    public static function processBounces(): void
+    {
+        try {
+            $bounceHandler = new BounceHandler();
+            $results = $bounceHandler->processBounces();
+            
+            if ($results['processed'] > 0) {
+                echo "Bounce processing completed:\n";
+                echo "- Total processed: " . $results['processed'] . "\n";
+                echo "- Hard bounces: " . $results['hard_bounces'] . "\n";
+                echo "- Soft bounces: " . $results['soft_bounces'] . "\n";
+                echo "- Spam complaints: " . $results['spam_complaints'] . "\n";
+                
+                if (!empty($results['errors'])) {
+                    echo "Errors:\n";
+                    foreach ($results['errors'] as $error) {
+                        echo "- " . $error . "\n";
+                    }
+                }
+            } else {
+                echo "No bounced emails to process.\n";
+            }
+            
+        } catch (\Exception $e) {
+            echo "Error processing bounces: " . $e->getMessage() . "\n";
+        }
+    }
+}

--- a/lib/User.php
+++ b/lib/User.php
@@ -72,6 +72,9 @@ class User
     /** @var int Has privacy policy been accepted? 1 = yes, 0 = no */
     public int $privacy_policy_accepted = 0;
 
+    /** @var int Soft bounce counter for bounce management */
+    public int $soft_bounce_count = 0;
+
     /**
      * Get user data from database.
      * @param int $user_id user id
@@ -104,6 +107,7 @@ class User
             $this->updateip = (string) $result->getValue('updateip');
             $this->subscriptiontype = (string) $result->getValue('subscriptiontype');
             $this->privacy_policy_accepted = (int) $result->getValue('privacy_policy_accepted');
+            $this->soft_bounce_count = (int) $result->getValue('soft_bounce_count');
         }
     }
 

--- a/pages/bounces.php
+++ b/pages/bounces.php
@@ -1,0 +1,212 @@
+<?php
+
+use FriendsOfRedaxo\MultiNewsletter\BounceHandler;
+
+// Handle manual bounce processing
+if (filter_input(INPUT_POST, 'process_bounces')) {
+    try {
+        $bounceHandler = new BounceHandler();
+        $results = $bounceHandler->processBounces();
+        
+        if ($results['processed'] > 0) {
+            echo rex_view::success(
+                rex_i18n::msg('multinewsletter_bounce_processing_success', 
+                    $results['processed'],
+                    $results['hard_bounces'], 
+                    $results['soft_bounces'],
+                    $results['spam_complaints']
+                )
+            );
+        } else {
+            echo rex_view::info(rex_i18n::msg('multinewsletter_bounce_no_emails'));
+        }
+        
+        if (!empty($results['errors'])) {
+            foreach ($results['errors'] as $error) {
+                echo rex_view::warning($error);
+            }
+        }
+        
+    } catch (Exception $e) {
+        echo rex_view::error('Error: ' . $e->getMessage());
+    }
+}
+
+// Handle IMAP connection test
+if (filter_input(INPUT_POST, 'test_imap_connection')) {
+    try {
+        // Create temporary bounce handler with POST data
+        $bounceHandler = new BounceHandler();
+        // Test with current config or form data
+        if ($bounceHandler->testConnection()) {
+            echo 'success';
+        } else {
+            echo 'Connection failed';
+        }
+    } catch (Exception $e) {
+        echo 'Error: ' . $e->getMessage();
+    }
+    exit; // AJAX response
+}
+
+?>
+
+<div class="row">
+    <div class="col-lg-6">
+        <div class="rex-addon-output">
+            <div class="panel panel-edit">
+                <header class="panel-heading">
+                    <div class="panel-title">
+                        <?= rex_i18n::msg('multinewsletter_bounce_management') ?>
+                    </div>
+                </header>
+                <div class="panel-body">
+                    <p><?= rex_i18n::msg('multinewsletter_bounce_management_description') ?></p>
+                    
+                    <?php if (rex_addon::get('multinewsletter')->getConfig('bounce_enabled') === 'active'): ?>
+                        <form action="<?= rex_url::currentBackendPage() ?>" method="post">
+                            <button type="submit" name="process_bounces" class="btn btn-primary">
+                                <i class="rex-icon rex-icon-refresh"></i>
+                                <?= rex_i18n::msg('multinewsletter_process_bounces_manually') ?>
+                            </button>
+                        </form>
+                    <?php else: ?>
+                        <div class="alert alert-info">
+                            <?= rex_i18n::msg('multinewsletter_bounce_management_disabled') ?>
+                            <a href="<?= rex_url::backendPage('multinewsletter/settings') ?>" class="btn btn-xs btn-primary">
+                                <?= rex_i18n::msg('multinewsletter_enable_bounce_management') ?>
+                            </a>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-lg-6">
+        <div class="rex-addon-output">
+            <div class="panel panel-edit">
+                <header class="panel-heading">
+                    <div class="panel-title">
+                        <?= rex_i18n::msg('multinewsletter_bounce_statistics') ?>
+                    </div>
+                </header>
+                <div class="panel-body">
+                    <?php
+                    try {
+                        $bounceHandler = new BounceHandler();
+                        $stats = $bounceHandler->getBounceStatistics(30);
+                    ?>
+                        <div class="row">
+                            <div class="col-sm-6">
+                                <div class="rex-tile">
+                                    <div class="rex-tile-number"><?= $stats['total'] ?></div>
+                                    <div class="rex-tile-text"><?= rex_i18n::msg('multinewsletter_total_bounces_30_days') ?></div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6">
+                                <div class="rex-tile">
+                                    <div class="rex-tile-number"><?= $stats['hard_bounces'] ?></div>
+                                    <div class="rex-tile-text"><?= rex_i18n::msg('multinewsletter_hard_bounces') ?></div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6">
+                                <div class="rex-tile">
+                                    <div class="rex-tile-number"><?= $stats['soft_bounces'] ?></div>
+                                    <div class="rex-tile-text"><?= rex_i18n::msg('multinewsletter_soft_bounces') ?></div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6">
+                                <div class="rex-tile">
+                                    <div class="rex-tile-number"><?= $stats['spam_complaints'] ?></div>
+                                    <div class="rex-tile-text"><?= rex_i18n::msg('multinewsletter_spam_complaints') ?></div>
+                                </div>
+                            </div>
+                        </div>
+                    <?php
+                    } catch (Exception $e) {
+                        echo '<div class="alert alert-warning">' . rex_i18n::msg('multinewsletter_bounce_stats_error') . '</div>';
+                    }
+                    ?>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Recent Bounces -->
+<div class="row">
+    <div class="col-lg-12">
+        <div class="rex-addon-output">
+            <div class="panel panel-edit">
+                <header class="panel-heading">
+                    <div class="panel-title">
+                        <?= rex_i18n::msg('multinewsletter_recent_bounces') ?>
+                    </div>
+                </header>
+                <div class="panel-body">
+                    <?php
+                    try {
+                        $sql = rex_sql::factory();
+                        $sql->setQuery('
+                            SELECT b.*, u.email, u.firstname, u.lastname 
+                            FROM ' . rex::getTablePrefix() . '375_bounces b
+                            LEFT JOIN ' . rex::getTablePrefix() . '375_user u ON b.user_id = u.id
+                            ORDER BY b.created_at DESC 
+                            LIMIT 20
+                        ');
+                        
+                        if ($sql->getRows() > 0) {
+                            echo '<div class="table-responsive">';
+                            echo '<table class="table table-striped">';
+                            echo '<thead>';
+                            echo '<tr>';
+                            echo '<th>' . rex_i18n::msg('multinewsletter_bounce_date') . '</th>';
+                            echo '<th>' . rex_i18n::msg('multinewsletter_bounce_user') . '</th>';
+                            echo '<th>' . rex_i18n::msg('multinewsletter_bounce_type') . '</th>';
+                            echo '<th>' . rex_i18n::msg('multinewsletter_bounce_subject') . '</th>';
+                            echo '</tr>';
+                            echo '</thead>';
+                            echo '<tbody>';
+                            
+                            for ($i = 0; $i < $sql->getRows(); $i++) {
+                                $bounce_type = $sql->getValue('bounce_type');
+                                $user_name = trim($sql->getValue('firstname') . ' ' . $sql->getValue('lastname'));
+                                
+                                echo '<tr>';
+                                echo '<td>' . date('d.m.Y H:i', strtotime($sql->getValue('created_at'))) . '</td>';
+                                echo '<td>' . htmlspecialchars($user_name ?: $sql->getValue('email')) . '<br><small>' . htmlspecialchars($sql->getValue('email')) . '</small></td>';
+                                echo '<td>';
+                                switch ($bounce_type) {
+                                    case 'hard_bounces':
+                                        echo '<span class="label label-danger">' . rex_i18n::msg('multinewsletter_hard_bounce') . '</span>';
+                                        break;
+                                    case 'soft_bounces':
+                                        echo '<span class="label label-warning">' . rex_i18n::msg('multinewsletter_soft_bounce') . '</span>';
+                                        break;
+                                    case 'spam_complaints':
+                                        echo '<span class="label label-default">' . rex_i18n::msg('multinewsletter_spam_complaint') . '</span>';
+                                        break;
+                                }
+                                echo '</td>';
+                                echo '<td>' . htmlspecialchars($sql->getValue('subject')) . '</td>';
+                                echo '</tr>';
+                                
+                                $sql->next();
+                            }
+                            
+                            echo '</tbody>';
+                            echo '</table>';
+                            echo '</div>';
+                        } else {
+                            echo '<div class="alert alert-info">' . rex_i18n::msg('multinewsletter_no_bounces_yet') . '</div>';
+                        }
+                    } catch (Exception $e) {
+                        echo '<div class="alert alert-warning">' . rex_i18n::msg('multinewsletter_bounce_list_error') . '</div>';
+                    }
+                    ?>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/pages/settings.settings.php
+++ b/pages/settings.settings.php
@@ -295,6 +295,67 @@ foreach (rex_clang::getAll() as $rex_clang) {
 			</fieldset>
 
 			<fieldset>
+				<legend><?= rex_i18n::msg('multinewsletter_config_title_bounce_management') ?></legend>
+				<div class="panel-body-wrapper slide">
+					<dl class="rex-form-group form-group">
+						<dt><label for="expl_bounce_management"></label></dt>
+						<dd><?= rex_i18n::msg('multinewsletter_expl_bounce_management') ?></dd>
+					</dl>
+					<?php
+                        \TobiasKrais\D2UHelper\BackendHelper::form_checkbox('multinewsletter_config_bounce_enabled', 'settings[bounce_enabled]', 'active', 'active' === rex_config::get('multinewsletter', 'bounce_enabled', 'inactive'));
+                        \TobiasKrais\D2UHelper\BackendHelper::form_input('multinewsletter_config_bounce_imap_host', 'settings[bounce_imap_host]', (string) rex_config::get('multinewsletter', 'bounce_imap_host'));
+                        \TobiasKrais\D2UHelper\BackendHelper::form_input('multinewsletter_config_bounce_imap_port', 'settings[bounce_imap_port]', (int) rex_config::get('multinewsletter', 'bounce_imap_port', 993), false, false, 'number');
+                        \TobiasKrais\D2UHelper\BackendHelper::form_input('multinewsletter_config_bounce_imap_user', 'settings[bounce_imap_user]', (string) rex_config::get('multinewsletter', 'bounce_imap_user'));
+                        \TobiasKrais\D2UHelper\BackendHelper::form_input('multinewsletter_config_bounce_imap_password', 'settings[bounce_imap_password]', (string) rex_config::get('multinewsletter', 'bounce_imap_password'), false, false, 'password');
+                        \TobiasKrais\D2UHelper\BackendHelper::form_select('multinewsletter_config_bounce_imap_ssl', 'settings[bounce_imap_ssl]', [0 => rex_i18n::msg('no'), 1 => rex_i18n::msg('yes')], [(int) rex_config::get('multinewsletter', 'bounce_imap_ssl', 1)]);
+                        \TobiasKrais\D2UHelper\BackendHelper::form_input('multinewsletter_config_bounce_imap_mailbox', 'settings[bounce_imap_mailbox]', (string) rex_config::get('multinewsletter', 'bounce_imap_mailbox', 'INBOX'));
+                        
+                        // Test connection button
+                        echo '<dl class="rex-form-group form-group">';
+                        echo '<dt><label></label></dt>';
+                        echo '<dd><button type="button" class="btn btn-primary" onclick="testImapConnection()">' . rex_i18n::msg('multinewsletter_config_test_imap_connection') . '</button>';
+                        echo '<div id="imap-test-result" style="margin-top: 10px;"></div></dd>';
+                        echo '</dl>';
+                        
+                        if (rex_addon::get('cronjob')->isAvailable()) {
+                            \TobiasKrais\D2UHelper\BackendHelper::form_checkbox('multinewsletter_config_bounce_auto_process', 'settings[bounce_auto_process]', 'active', 'active' === rex_config::get('multinewsletter', 'bounce_auto_process') && FriendsOfRedaxo\MultiNewsletter\CronjobBounceProcessor::factory()->isInstalled());
+                        }
+                    ?>
+                    <script>
+                        function testImapConnection() {
+                            var resultDiv = document.getElementById('imap-test-result');
+                            resultDiv.innerHTML = '<div class="alert alert-info">Testing IMAP connection...</div>';
+                            
+                            var formData = new FormData();
+                            formData.append('bounce_imap_host', document.querySelector('input[name="settings[bounce_imap_host]"]').value);
+                            formData.append('bounce_imap_port', document.querySelector('input[name="settings[bounce_imap_port]"]').value);
+                            formData.append('bounce_imap_user', document.querySelector('input[name="settings[bounce_imap_user]"]').value);
+                            formData.append('bounce_imap_password', document.querySelector('input[name="settings[bounce_imap_password]"]').value);
+                            formData.append('bounce_imap_ssl', document.querySelector('select[name="settings[bounce_imap_ssl]"]').value);
+                            formData.append('bounce_imap_mailbox', document.querySelector('input[name="settings[bounce_imap_mailbox]"]').value);
+                            formData.append('test_imap_connection', '1');
+                            
+                            fetch('', {
+                                method: 'POST',
+                                body: formData
+                            })
+                            .then(response => response.text())
+                            .then(data => {
+                                if (data.includes('success')) {
+                                    resultDiv.innerHTML = '<div class="alert alert-success">IMAP connection successful!</div>';
+                                } else {
+                                    resultDiv.innerHTML = '<div class="alert alert-danger">IMAP connection failed: ' + data + '</div>';
+                                }
+                            })
+                            .catch(error => {
+                                resultDiv.innerHTML = '<div class="alert alert-danger">Error testing connection: ' + error + '</div>';
+                            });
+                        }
+                    </script>
+				</div>
+			</fieldset>
+
+			<fieldset>
 				<legend><?= rex_i18n::msg('multinewsletter_config_title_mailchimp') ?></legend>
 				<div class="panel-body-wrapper slide">
 					<dl class="rex-form-group form-group">

--- a/update.php
+++ b/update.php
@@ -17,6 +17,30 @@ if (rex_sql_table::get(rex::getTable('375_archive'))->hasColumn('archive_id')) {
     $sql->setQuery('ALTER TABLE  ' . rex::getTablePrefix() . '375_archive CHANGE `archive_id` `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT;');
 }
 
+// Add soft_bounce_count column to user table for bounce management
+if (!rex_sql_table::get(rex::getTable('375_user'))->hasColumn('soft_bounce_count')) {
+    $sql->setQuery('ALTER TABLE ' . rex::getTablePrefix() . '375_user ADD `soft_bounce_count` INT(11) UNSIGNED NOT NULL DEFAULT 0');
+}
+
+// Create bounces table for bounce logging
+if (!rex_sql_table::get(rex::getTablePrefix() . '375_bounces')) {
+    $sql->setQuery('
+        CREATE TABLE IF NOT EXISTS ' . rex::getTablePrefix() . '375_bounces (
+            `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+            `user_id` INT(11) UNSIGNED NOT NULL,
+            `bounce_type` ENUM("hard_bounces", "soft_bounces", "spam_complaints") NOT NULL,
+            `subject` VARCHAR(255) NOT NULL DEFAULT "",
+            `body_excerpt` TEXT,
+            `created_at` DATETIME NOT NULL,
+            PRIMARY KEY (`id`),
+            KEY `user_id` (`user_id`),
+            KEY `bounce_type` (`bounce_type`),
+            KEY `created_at` (`created_at`),
+            FOREIGN KEY (`user_id`) REFERENCES ' . rex::getTablePrefix() . '375_user (`id`) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    ');
+}
+
 // use path relative to __DIR__ to get correct path in update temp dir
 $this->includeFile(__DIR__.'/install.php'); /** @phpstan-ignore-line */
 


### PR DESCRIPTION
@TobiasKrais vielleicht hilft es bei Deiner Entwicklung 

**Zusammenfassung der Implementierung:**
🔧 Hauptkomponenten:
BounceHandler.php - Kernklasse für IMAP-Bounce-Verarbeitung

**Verbindet zu IMAP-Postfach und liest Bounce-E-Mails**
Erkennt Hard/Soft Bounces und Spam-Beschwerden automatisch
Verwaltet Benutzer-Status basierend auf Bounce-Typ
CronjobBounceProcessor.php - Cronjob für automatische Verarbeitung

**Läuft alle 30 Minuten automatisch**
Verarbeitet neue Bounces ohne manuellen Eingriff
Erweiterte Einstellungen - IMAP-Konfiguration

**IMAP Server, Port, Credentials**
SSL/TLS Unterstützung
Postfach-Auswahl
Verbindungstest-Funktion
Bounce-Statistiken Seite - Monitoring & Management

**Übersicht über Bounce-Statistiken**
Manuelle Bounce-Verarbeitung
Liste der aktuellen Bounces


- Hard Bounces: Sofortige Deaktivierung bei permanenten Fehlern
- Soft Bounces: Retry-Logik (3 Versuche), dann Deaktivierung
- Spam Complaints: Automatisches Unsubscribe
- Detaillierte Statistiken: 30-Tage Übersicht, Bounce-Trends
- Automatische Verarbeitung: Via Cronjob alle 30 Minuten
- Bounce-Logging: Vollständige Nachverfolgung aller Bounces


- IMAP-Integration: Nutzt PHP IMAP Extension
- Pattern-basierte Erkennung: Intelligente Bounce-Klassifizierung
- Datenbank-Schema: Neue Bounce-Tabelle für Logging
- User-Erweiterung: soft_bounce_count Feld hinzugefügt
- Mehrsprachig: Deutsche & englische Übersetzungen