### PR TITLE
Fix comma in group name breaking checkbox list in module 80-9

### DIFF
--- a/modules/80/9/output.php
+++ b/modules/80/9/output.php
@@ -95,9 +95,11 @@ if (strlen($activationkey) > 5 && false !== $email) {
         $group_options = [];
         foreach ($group_ids as $group_id) {
             $group = new FriendsOfRedaxo\MultiNewsletter\Group($group_id);
-            $group_options[] = $group->name .'='. $group_id;
+            $group_options[$group->name] = (string) $group_id;
         }
-        $form_data .= 'choice|group_ids|'. $addon->getConfig('lang_'. rex_clang::getCurrentId() .'_select_newsletter', '') .'|'. implode(',', $group_options) .'|1|1|
+        // Use JSON instead of "label=value,label2=value2", otherwise a comma
+        // in a group name would be misinterpreted as a separator between choices
+        $form_data .= 'choice|group_ids|'. $addon->getConfig('lang_'. rex_clang::getCurrentId() .'_select_newsletter', '') .'|'. json_encode($group_options, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) .'|1|1|
 			html||<br><br>'. PHP_EOL;
     }
 

--- a/pages/help.changelog.php
+++ b/pages/help.changelog.php
@@ -2,7 +2,7 @@
 	<legend>MultiNewsletter Changelog</legend>
 	<p>3.8.5-DEV</p>
 	<ul>
-		<li>...</li>
+		<li>Bugfix: In Modul 80-9 wurde die Gruppenauswahl als kommaseparierte Liste ("Name=ID,Name2=ID2") an YForm übergeben. Enthielt ein Gruppenname selbst ein Komma, wurde er von YForm in mehrere einzelne Checkboxen aufgesplittet. Die Choices werden jetzt als JSON übergeben.</li>
 	</ul>
 	<p>3.8.4</p>
 	<ul>


### PR DESCRIPTION
Fixes #15

The group choices in module 80-9 were built as a comma-separated `label=value` string. YForm's `choice` field splits its choices on commas, so a group name containing a comma (e.g. "Party, Musik, Feste") got split into several separate checkboxes instead of staying one option.

This switches the choices to YForm's JSON format instead (supported by `rex_yform_choice_list::createListFromJson`, which is used whenever the choices string starts with `{`), which keeps commas in group names intact. No other behavior changes (still `expanded=1`, `multiple=1`, no default selection).

Also added a changelog entry under 3.8.5-DEV per AGENTS.md.